### PR TITLE
S3 path fix

### DIFF
--- a/prerender/cache/s3.py
+++ b/prerender/cache/s3.py
@@ -60,8 +60,6 @@ class S3Cache(CacheBackend):
         )
 
     def _filename(self, url, format):
-        hex_name = codecs.encode(url.encode('utf-8'), 'hex').decode('utf-8')
-        sub_dir = os.path.join(hex_name[:2], hex_name[2:4])
-        name = hex_name[4:] + '.{}'.format(format)
         parsed_url = urlparse(url)
-        return os.path.join(parsed_url.hostname, sub_dir, name)
+        encoded_name = urlencode(parsed_url.path)
+        return os.path.join(parsed_url.hostname, encoded_name)

--- a/prerender/cache/s3.py
+++ b/prerender/cache/s3.py
@@ -2,7 +2,7 @@ import os
 import io
 import codecs
 import asyncio
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlencode
 from typing import Optional
 
 import minio

--- a/prerender/cache/s3.py
+++ b/prerender/cache/s3.py
@@ -62,4 +62,6 @@ class S3Cache(CacheBackend):
     def _filename(self, url, format):
         parsed_url = urlparse(url)
         encoded_name = urlencode(parsed_url.path)
+        if parsed_url.query:
+            encoded_name += '?{}'.format(urlencode(parsed_url.query))
         return os.path.join(parsed_url.hostname, encoded_name)


### PR DESCRIPTION
There is no need in hash functions to distribute across subdirs, just use urlencode for readability.
Resolves #23 